### PR TITLE
Disabled 'connection: keep-alive' header

### DIFF
--- a/piapi.py
+++ b/piapi.py
@@ -135,7 +135,9 @@ class PIAPI(object):
 
         self.session = requests.Session()
         self.session.auth = requests.auth.HTTPBasicAuth(username, password)
-        self.session.keep_alive = False  # Disable HTTP keep_alive as advised by the API documentation
+
+        # Disable HTTP keep_alive as advised by the API documentation
+        self.session.headers['connection'] = 'close'
 
         # Don't print warning message from request if not wanted
         if not self.verify:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     name='piapi',
     version='0.1.3',
     py_modules=['piapi'],
-    requires=['requests'],
+    install_requires=['requests>=2.4.0'],
     platforms='any',
     url='https://github.com/maximumG/piapi',
     download_url='https://github.com/maximumG/piapi/tarball/0.1.3',


### PR DESCRIPTION
Disabled the 'connection: keep-alive' header in accordance with the Prime API guide. Also updated the setup.py to install the requests package of proper version.
