### PR TITLE
Use correct content type for POST requests.

### DIFF
--- a/piapi.py
+++ b/piapi.py
@@ -354,7 +354,7 @@ class PIAPI(object):
         # if the HTTP method is 'GET', use the params args of request, otherwise use data (POST, DELETE, PUT)
         if method == "GET":
             response = self.session.request(method, url, params=params, verify=self.verify, timeout=timeout)
-        elif method == "PUT":
+        elif method == "PUT" or method == "POST":
             response = self.session.request(method, url, data=json.dumps(params), headers=headers, verify=self.verify, timeout=timeout)
         else:
             response = self.session.request(method, url, data=params, verify=self.verify, timeout=timeout)


### PR DESCRIPTION
I think the POST requests need the same JSON content type header as the PUT requests, see https://github.com/HSRNetwork/piapi/commit/5189b156a04bcab7a9d1a56a08184e721401f888.